### PR TITLE
Updating the tesla adapter protocols to use http1

### DIFF
--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -108,8 +108,12 @@ defmodule OpenAI.Client do
   def with_stream_opts(%{stream: true}, opts) do
     # This looks weird, but is the format that Tesla requires in order to
     # properly set the adapter options.
-    Keyword.put(opts, :opts, adapter: [body_as: :stream])
+    # The protocols is part of an open issue with Tesla where HTTP2 cannot upload more than 65535 bytes
+    Keyword.put(opts, :opts, adapter: [body_as: :stream, protocols: [:http1]])
   end
 
-  def with_stream_opts(_params, opts), do: opts
+  def with_stream_opts(_params, opts), do
+    # The protocols is part of an open issue with Tesla where HTTP2 cannot upload more than 65535 bytes
+    Keyword.put(opts, :opts, adapter: [protocols: [:http1]])
+  end
 end

--- a/lib/openai/client.ex
+++ b/lib/openai/client.ex
@@ -112,7 +112,7 @@ defmodule OpenAI.Client do
     Keyword.put(opts, :opts, adapter: [body_as: :stream, protocols: [:http1]])
   end
 
-  def with_stream_opts(_params, opts), do
+  def with_stream_opts(_params, opts) do
     # The protocols is part of an open issue with Tesla where HTTP2 cannot upload more than 65535 bytes
     Keyword.put(opts, :opts, adapter: [protocols: [:http1]])
   end

--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule OpenAI.MixProject do
   def project do
     [
       app: :openai_client,
-      version: "0.4.1",
+      version: "0.4.2",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
There's a well documented error with Tesla where the http2 cannot send more than 65535 bytes. The issue is documented here: https://github.com/elixir-tesla/tesla/issues/394

This is a workaround until Tesla gets their workaround implemented.